### PR TITLE
Use `noargs` for command-line argument handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,56 +3,6 @@
 version = 4
 
 [[package]]
-name = "anstream"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
-dependencies = [
- "anstyle",
- "once_cell",
- "windows-sys",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,52 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "4.5.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
 name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,18 +25,6 @@ dependencies = [
  "r-efi",
  "wasi",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -157,12 +49,6 @@ name = "noargs"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cf55508d4657f634cc0a40b190c3975e10fb3a50eb2bd088b666014c3496aa"
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ppv-lite86"
@@ -231,7 +117,6 @@ dependencies = [
 name = "rjg"
 version = "0.1.0"
 dependencies = [
- "clap",
  "noargs",
  "rand",
  "rand_chacha",
@@ -278,12 +163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,12 +180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,79 +187,6 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "noargs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cf55508d4657f634cc0a40b190c3975e10fb3a50eb2bd088b666014c3496aa"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +232,7 @@ name = "rjg"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "noargs",
  "rand",
  "rand_chacha",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "noargs"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cf55508d4657f634cc0a40b190c3975e10fb3a50eb2bd088b666014c3496aa"
+checksum = "28e00927e9eb7ac85489edf409d76c1b115157430622bc337762378277111f6f"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 
 [dependencies]
 clap = { version = "4.5.17", features = ["derive"] }
+noargs = "0.2.0"
 rand = "0.9.0"
 rand_chacha = "0.9.0"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/sile/rjg"
 readme = "README.md"
 
 [dependencies]
-clap = { version = "4.5.17", features = ["derive"] }
 noargs = "0.2.0"
 rand = "0.9.0"
 rand_chacha = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/sile/rjg"
 readme = "README.md"
 
 [dependencies]
-noargs = "0.2.0"
+noargs = "0.2.1"
 rand = "0.9.0"
 rand_chacha = "0.9.0"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -28,20 +28,23 @@ $ rjg --count 3 \
 
 // Print help.
 $ rjg -h
-Random JSON generator
+Random JSON Generator
 
 Usage: rjg [OPTIONS] <JSON_TEMPLATE>
 
+Example:
+  $ rjg '[0, {"$int": {"min": 1, "max": 8}}, 9]'
+
 Arguments:
-  <JSON_TEMPLATE>  JSON template used to generate values
+  <JSON_TEMPLATE> JSON template used to generate values
 
 Options:
-  -c, --count <COUNT>             Number of JSON values to generate [default: 1]
-  -p, --prefix <PREFIX>           Prefix for variable and generator names [default: $]
-  -s, --seed <SEED>               Seed for the random number generator
-  -v, --var <NAME=JSON_TEMPLATE>  User-defined variables
-  -h, --help                      Print help
-  -V, --version                   Print version
+  -h, --help                     Print help ('--help' for full help, '-h' for summary)
+      --version                  Print version
+  -c, --count <INTEGER>          Number of JSON values to generate [default: 1]
+  -p, --prefix <STRING>          Prefix for variable and generator names [default: $]
+  -s, --seed <INTEGER>           Seed for the random number generator
+  -v, --var <NAME=JSON_TEMPLATE> User-defined variables
 ```
 
 Rules

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,91 @@
 use std::{collections::HashMap, io, num::NonZeroUsize, str::FromStr};
 
-use clap::Parser;
 use rand::{Rng, SeedableRng, seq::IndexedRandom};
 use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize, de::Error};
 use serde_json::Value;
 
-#[derive(Parser)]
-#[clap(version)]
-/// Random JSON generator.
 struct Args {
-    /// Number of JSON values to generate.
-    #[clap(short, long, default_value = "1")]
     count: NonZeroUsize,
-
-    /// Prefix for variable and generator names.
-    #[clap(short, long, default_value = "$")]
     prefix: String,
 
     /// Seed for the random number generator.
-    #[clap(short, long)]
+    //#[clap(short, long)]
     seed: Option<u64>,
 
     /// User-defined variables.
-    #[clap(short, long, value_name = "NAME=JSON_TEMPLATE")]
+    //#[clap(short, long, value_name = "NAME=JSON_TEMPLATE")]
     var: Vec<Var>,
 
     /// JSON template used to generate values.
     json_template: Json,
 }
 
-fn main() {
-    let args = Args::parse();
+impl Args {
+    fn parse() -> noargs::Result<Option<Self>> {
+        let mut args = noargs::raw_args();
+        args.metadata_mut().app_name = env!("CARGO_PKG_NAME");
+        args.metadata_mut().app_description = env!("CARGO_PKG_DESCRIPTION");
+
+        noargs::HELP_FLAG.take_help(&mut args);
+        if noargs::VERSION_FLAG.take(&mut args).is_present() {
+            println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+            return Ok(None);
+        }
+
+        let this = Self {
+            count: noargs::opt("count")
+                .short('c')
+                .ty("INTEGER")
+                .default("1")
+                .doc("Number of JSON values to generate")
+                .take(&mut args)
+                .parse()?,
+            prefix: noargs::opt("prefix")
+                .short('p')
+                .ty("STRING")
+                .default("$")
+                .doc("Prefix for variable and generator names")
+                .take(&mut args)
+                .parse()?,
+            seed: noargs::opt("seed")
+                .short('s')
+                .ty("INTEGER")
+                .doc("Seed for the random number generator")
+                .take(&mut args)
+                .parse_if_present()?,
+            var: {
+                let mut vars = Vec::new();
+                while let Some(var) = noargs::opt("var")
+                    .short('v')
+                    .ty("NAME=JSON_TEMPLATE")
+                    .doc("User-defined variables")
+                    .take(&mut args)
+                    .parse_if_present()?
+                {
+                    vars.push(var);
+                }
+                vars
+            },
+            json_template: noargs::arg("JSON_TEMPLATE")
+                .doc("JSON template used to generate values")
+                .take(&mut args)
+                .parse()?,
+        };
+
+        if let Some(help) = args.finish()? {
+            print!("{help}");
+            Ok(None)
+        } else {
+            Ok(Some(this))
+        }
+    }
+}
+
+fn main() -> noargs::Result<()> {
+    let Some(args) = Args::parse()? else {
+        return Ok(());
+    };
     let mut generator = Generator::new(&args);
     let mut rng = ChaChaRng::seed_from_u64(args.seed.unwrap_or_else(rand::random));
     for i in 0..args.count.get() {
@@ -45,6 +99,7 @@ fn main() {
             }
         }
     }
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ impl Args {
             },
             json_template: noargs::arg("JSON_TEMPLATE")
                 .doc("JSON template used to generate values")
+                .example(r#"[0, {"$int": {"min": 1, "max": 8}}, 9]"#)
                 .take(&mut args)
                 .parse()?,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,16 +8,8 @@ use serde_json::Value;
 struct Args {
     count: NonZeroUsize,
     prefix: String,
-
-    /// Seed for the random number generator.
-    //#[clap(short, long)]
     seed: Option<u64>,
-
-    /// User-defined variables.
-    //#[clap(short, long, value_name = "NAME=JSON_TEMPLATE")]
     var: Vec<Var>,
-
-    /// JSON template used to generate values.
     json_template: Json,
 }
 


### PR DESCRIPTION
# Copilot Summary 

This pull request introduces significant changes to the `rjg` project, including a switch from the `clap` crate to the `noargs` crate for argument parsing, updates to the `README.md` to reflect these changes, and modifications to the `Cargo.toml` dependencies. The most important changes are summarized below:

### Argument Parsing

* Replaced the `clap` crate with the `noargs` crate for argument parsing in `src/main.rs`. This includes the removal of `clap`-specific annotations and the introduction of `noargs`-specific parsing logic. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL3-R89) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR103)

### Documentation

* Updated the `README.md` to reflect changes in the command-line interface, including new examples and updated option descriptions.

### Dependencies

* Updated the `Cargo.toml` to replace the `clap` dependency with `noargs` and adjusted other dependencies accordingly.